### PR TITLE
fix: wrong party status code

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -17,7 +17,7 @@ export enum PartyStatusCode {
   gone = 'Gone',
   parked = 'Parked',
   hold = 'Hold',
-  voicemail = 'VoiceMail',
+  voicemail = 'Voicemail',
   faxReceive = 'FaxReceive',
   voicemailScreening = 'VoiceMailScreening',
 }


### PR DESCRIPTION
Hi embbnux, if here should be same as PLA's response? blew is the response from PLA. Which with lower case 'Voicemail'.
![image](https://user-images.githubusercontent.com/12573233/94589335-bbebde00-02b7-11eb-926f-441edefe4160.png)
